### PR TITLE
feat(Model): creation classes parrainEntity et porteurEntity

### DIFF
--- a/src/main/java/fr/initiativedeuxsevres/ttm/model/ParrainEntity.java
+++ b/src/main/java/fr/initiativedeuxsevres/ttm/model/ParrainEntity.java
@@ -1,12 +1,20 @@
 package fr.initiativedeuxsevres.ttm.model;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
 
 @Data
+@Entity
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@Table(name = "parrains")
 public class ParrainEntity extends UserEntity {
     private String entrepriseRepresentee;
     private String plateformeInitiative;
-    private String codeAcces;
     private String presentationParcours;
     private String branchesBonReseau;
     private String domaineExpertise;

--- a/src/main/java/fr/initiativedeuxsevres/ttm/model/ParrainEntity.java
+++ b/src/main/java/fr/initiativedeuxsevres/ttm/model/ParrainEntity.java
@@ -1,0 +1,15 @@
+package fr.initiativedeuxsevres.ttm.model;
+
+import lombok.Data;
+
+@Data
+public class ParrainEntity extends UserEntity {
+    private String entrepriseRepresentee;
+    private String plateformeInitiative;
+    private String codeAcces;
+    private String presentationParcours;
+    private String branchesBonReseau;
+    private String domaineExpertise;
+    private String lieuxDeplacement;
+    private String disponibilites;
+}

--- a/src/main/java/fr/initiativedeuxsevres/ttm/model/PorteurEntity.java
+++ b/src/main/java/fr/initiativedeuxsevres/ttm/model/PorteurEntity.java
@@ -1,0 +1,16 @@
+package fr.initiativedeuxsevres.ttm.model;
+
+import lombok.Data;
+
+@Data
+public class PorteurEntity extends UserEntity {
+    private String entreprise;
+    private String plateformeInitiative;
+    private String dateLancement;
+    private String domaineActivite;
+    private String description;
+    private String besoinsPotentiels;
+    private String lieuActivite;
+    private String disponibilites;
+
+}

--- a/src/main/java/fr/initiativedeuxsevres/ttm/model/PorteurEntity.java
+++ b/src/main/java/fr/initiativedeuxsevres/ttm/model/PorteurEntity.java
@@ -1,8 +1,16 @@
 package fr.initiativedeuxsevres.ttm.model;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
 
 @Data
+@Entity
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@Table(name = "porteurs")
 public class PorteurEntity extends UserEntity {
     private String entreprise;
     private String plateformeInitiative;

--- a/src/main/java/fr/initiativedeuxsevres/ttm/model/UserEntity.java
+++ b/src/main/java/fr/initiativedeuxsevres/ttm/model/UserEntity.java
@@ -19,4 +19,7 @@ public class UserEntity {
     String prenom;
     String plateformeInitiative;
     Role role;
+
+    public UserEntity() {
+    }
 }

--- a/src/main/java/fr/initiativedeuxsevres/ttm/model/UserEntity.java
+++ b/src/main/java/fr/initiativedeuxsevres/ttm/model/UserEntity.java
@@ -3,18 +3,21 @@ package fr.initiativedeuxsevres.ttm.model;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Table;
-import lombok.Builder;
 import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
 @Data
-@Entity
-@Builder
-@Table(name = "users")
+@SuperBuilder
+@MappedSuperclass
 public class UserEntity {
     @Id
     @GeneratedValue
     Long id;
+    String username;
     String nom;
     String prenom;
     String plateformeInitiative;

--- a/src/main/java/fr/initiativedeuxsevres/ttm/repository/UserRepository.java
+++ b/src/main/java/fr/initiativedeuxsevres/ttm/repository/UserRepository.java
@@ -1,13 +1,13 @@
-package fr.initiativedeuxsevres.ttm.repository;
-
-import java.util.Optional;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-import fr.initiativedeuxsevres.ttm.model.UserEntity;
-
-@Repository
-public interface UserRepository extends JpaRepository <UserEntity, Long> {
-    Optional<UserEntity> findByUsername(String username);
-}
+//package fr.initiativedeuxsevres.ttm.repository;
+//
+//import java.util.Optional;
+//
+//import org.springframework.data.jpa.repository.JpaRepository;
+//import org.springframework.stereotype.Repository;
+//
+//import fr.initiativedeuxsevres.ttm.model.UserEntity;
+//
+//@Repository
+//public interface UserRepository extends JpaRepository <UserEntity, Long> {
+//    Optional<UserEntity> findByUsername(String username);
+//}

--- a/src/main/java/fr/initiativedeuxsevres/ttm/service/UserService.java
+++ b/src/main/java/fr/initiativedeuxsevres/ttm/service/UserService.java
@@ -1,37 +1,37 @@
-package fr.initiativedeuxsevres.ttm.service;
-
-import java.util.NoSuchElementException;
-import java.util.Optional;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import fr.initiativedeuxsevres.ttm.model.Role;
-import fr.initiativedeuxsevres.ttm.model.UserEntity;
-import fr.initiativedeuxsevres.ttm.repository.UserRepository;
-
-@Service
-public class UserService {
-
-    @Autowired
-    private UserRepository userRepository;
-
-    /**
-     * Crée un nouvel utilisateur et le sauvegarde
-     * @param user L'entité user à créer
-     * @return L'entité user créée et sauvegardée
-     */
-    public UserEntity createUser(UserEntity user) {
-        return userRepository.save(user);
-    }
-
-    public void deleteUserById(Long userId) {
-        Optional<UserEntity> maybeUser = userRepository.findById(userId);
-        if (maybeUser.isPresent()) {
-            userRepository.deleteById(userId);
-            return;
-        }
-        String erreurMessage = String.format("L'utilisateur %d n'existe pas", userId);
-        throw new NoSuchElementException(erreurMessage);
-    }
-}
+//package fr.initiativedeuxsevres.ttm.service;
+//
+//import java.util.NoSuchElementException;
+//import java.util.Optional;
+//
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.stereotype.Service;
+//
+//import fr.initiativedeuxsevres.ttm.model.Role;
+//import fr.initiativedeuxsevres.ttm.model.UserEntity;
+//import fr.initiativedeuxsevres.ttm.repository.UserRepository;
+//
+//@Service
+//public class UserService {
+//
+//    @Autowired
+//    private UserRepository userRepository;
+//
+//    /**
+//     * Crée un nouvel utilisateur et le sauvegarde
+//     * @param user L'entité user à créer
+//     * @return L'entité user créée et sauvegardée
+//     */
+//    public UserEntity createUser(UserEntity user) {
+//        return userRepository.save(user);
+//    }
+//
+//    public void deleteUserById(Long userId) {
+//        Optional<UserEntity> maybeUser = userRepository.findById(userId);
+//        if (maybeUser.isPresent()) {
+//            userRepository.deleteById(userId);
+//            return;
+//        }
+//        String erreurMessage = String.format("L'utilisateur %d n'existe pas", userId);
+//        throw new NoSuchElementException(erreurMessage);
+//    }
+//}


### PR DESCRIPTION
Creation des classes PorteurEntity et ParrainEntity.
Classe UserEntity annotée avec @MappedSuperClass afin de ne pas créer de table pour cette classe.
UserRepository & UserService commentées.